### PR TITLE
Use consistent names across various CD models

### DIFF
--- a/model/cd_modules/baseline_attention.py
+++ b/model/cd_modules/baseline_attention.py
@@ -8,7 +8,6 @@ from model.cd_modules.psp import _PSPModule
 from model.cd_modules.se import ChannelSpatialSELayer
 
 import numpy as np
-from torchvision import models
 
 def get_in_channels(feat_scales, inner_channel, channel_multiplier):
     '''
@@ -277,16 +276,17 @@ class cd_head_v2(nn.Module):
                     f_A = torch.cat((f_A, feats_A[i][self.feat_scales[lvl]]), dim=1)
                     f_B = torch.cat((f_B, feats_B[i][self.feat_scales[lvl]]), dim=1)
     
-                f_A, f_B = layer(f_A), layer(f_B)
+                class_f_A, class_f_B = layer(f_A), layer(f_B)
                 if lvl!=0:
-                    f_A, f_B = f_A + f_A_acc, f_B + f_B_acc
+                    class_f_A, class_f_B = class_f_A + x_A, class_f_B + x_B
                 lvl+=1
             else:
-                f_A, f_B = layer(f_A), layer(f_B)
-                f_A_acc, f_B_acc = F.interpolate(f_A, scale_factor=2, mode="bilinear"), F.interpolate(f_B, scale_factor=2, mode="bilinear")
+                class_f_A, class_f_B = layer(class_f_A), layer(class_f_B)
+                x_A = F.interpolate(class_f_A, scale_factor=2, mode="bilinear")
+                x_B = F.interpolate(class_f_B, scale_factor=2, mode="bilinear")
 
         # Classifier
-        cm = self.classifier(f_A_acc, f_B_acc)
+        cm = self.classifier(x_A, x_B)
 
         return cm
 

--- a/model/cd_modules/baseline_fdaf_attention.py
+++ b/model/cd_modules/baseline_fdaf_attention.py
@@ -8,7 +8,6 @@ from model.cd_modules.psp import _PSPModule
 from model.cd_modules.se import ChannelSpatialSELayer
 
 import numpy as np
-from torchvision import models
 
 
 def get_in_channels(feat_scales, inner_channel, channel_multiplier):
@@ -354,18 +353,17 @@ class cd_head_v2(nn.Module):
                 for i in range(1, len(self.time_steps)):
                     f_A = torch.cat((f_A, feats_A[i][self.feat_scales[lvl]]), dim=1)
                     f_B = torch.cat((f_B, feats_B[i][self.feat_scales[lvl]]), dim=1)
-
-                f_A, f_B = layer(f_A), layer(f_B)
+    
+                class_f_A, class_f_B = layer(f_A), layer(f_B)
                 if lvl != 0:
-                    f_A, f_B = f_A + f_A_acc, f_B + f_B_acc
+                    class_f_A, class_f_B = class_f_A + x_A, class_f_B + x_B
                 lvl += 1
             elif isinstance(layer, AttentionBlock):
-                f_A, f_B = layer(f_A), layer(f_B)
-                f_A_acc, f_B_acc = F.interpolate(f_A, scale_factor=2, mode="bilinear"), F.interpolate(f_B,
-                                                                                                      scale_factor=2,
-                                                                                                      mode="bilinear")
+                class_f_A, class_f_B = layer(class_f_A), layer(class_f_B)
+                x_A = F.interpolate(class_f_A, scale_factor=2, mode="bilinear")
+                x_B = F.interpolate(class_f_B, scale_factor=2, mode="bilinear")
             else:
-                x1, x2 = layer(f_A_acc, f_B_acc, "Attention")
+                x1, x2 = layer(x_A, x_B, "Attention")
 
         # Classifier
         cm = self.classifier(x1, x2)


### PR DESCRIPTION
The naming of baseline_attention, baseline_attention_fdaf follows the baseline_fdaf file.